### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,7 +451,7 @@
     <repositories>
         <repository>
             <id>clojars</id>
-            <url>http://clojars.org/repo/</url>
+            <url>https://clojars.org/repo/</url>
         </repository>
         <repository>
             <id>tmatesoft</id>


### PR DESCRIPTION
changed http://clojars.org/repo/ to https://clojars.org/repo/

maven 3.8.1 requires https repositories see https://maven.apache.org/docs/3.8.1/release-notes.html